### PR TITLE
[ci] Remove the error_prone override for the javac-with-errorprone on…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,6 @@
                                     <artifactId>plexus-compiler-javac-errorprone</artifactId>
                                     <version>2.8.6</version>
                                 </dependency>
-                                <dependency>
-                                    <!--
-                                    Override plexus-compiler-javac-errorprone's dependency with the latest version
-                                    -->
-                                    <groupId>com.google.errorprone</groupId>
-                                    <artifactId>error_prone_core</artifactId>
-                                    <version>${linters.errorprone.version}</version>
-                                </dependency>
                             </dependencies>
                             <!-- /error_prone on jdk1.8 -->
 


### PR DESCRIPTION
… jdk8, as it fails there.